### PR TITLE
Android: NPE in RNAccountKitModule.onActivityResult()

### DIFF
--- a/android/src/main/java/io/underscope/react/fbak/RNAccountKitModule.java
+++ b/android/src/main/java/io/underscope/react/fbak/RNAccountKitModule.java
@@ -62,6 +62,10 @@ public class RNAccountKitModule extends ReactContextBaseJavaModule implements Ac
     @Override
     public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
         if (requestCode == APP_REQUEST_CODE) {
+            if (data == null) {
+                rejectPromise("error", new Error("Login failed"));
+                return;
+            }
             AccountKitLoginResult loginResult = data.getParcelableExtra(AccountKitLoginResult.RESULT_KEY);
 
             if (loginResult.getError() != null) {


### PR DESCRIPTION
Quite often I observe crashes `NullPointerException` in `io.underscope.react.fbak.RNAccountKitModule.onActivityResult()` line 65: Attempt to invoke virtual method 'android.os.Parcelable android.content.Intent.getParcelableExtra(java.lang.String)' on a null object reference.

I haven't found the original cause (i.e. why the `onActivityResult` with the proper `requestCode` gets `null` intent). The aim of this fix is to avoid crashes.