### PR TITLE
Using older FB AK SDK for compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,7 +20,7 @@ android {
 
 dependencies {
     compile 'com.facebook.react:react-native:+'
-    compile ('com.facebook.android:account-kit-sdk:4.+'){
+    compile ('com.facebook.android:account-kit-sdk:4.23.0'){
         exclude group: 'com.parse.bolts', module: 'bolts-android';
         exclude group: 'com.parse.bolts', module: 'bolts-applinks';
         exclude group: 'com.parse.bolts', module: 'bolts-tasks';


### PR DESCRIPTION
- Since Facebook released SDK 4.24.0 I started getting:
node_modules/react-native-facebook-account-kit/android/build/intermediates/res/merged/release/values-v24/values-v24.xml:3:
AAPT: Error retrieving parent for item:
No resource found that matches the given name 'android:TextAppearance.Material.Widget.Button.Borderless.Colored'.

As a temporary fix FB SDK is downgraded