### PR TITLE
#88 Bug: Compilation with RN 0.47 on Android fails

### DIFF
--- a/android/src/main/java/io/underscope/react/fbak/RNAccountKitPackage.java
+++ b/android/src/main/java/io/underscope/react/fbak/RNAccountKitPackage.java
@@ -13,7 +13,8 @@ import java.util.List;
 
 public class RNAccountKitPackage implements ReactPackage {
 
-    @Override
+    // DEPRECATED 0.47
+    //@Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
There is a a breaking change made in react native 0.47 "Remove unused createJSModules calls"