### PR TITLE
initialPhoneNumber without initialPhoneCountryPrefix on Android

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -232,7 +232,7 @@ RNAccountKit.configure({
   titleType: 'login',
   initialAuthState: '',
   initialEmail: 'some.initial@email.com',
-  initialPhoneCountryPrefix: '+1',
+  initialPhoneCountryPrefix: '+1', // autodetected if none is provided
   initialPhoneNumber: '123-456-7890',
   facebookNotificationsEnabled: true|false, // true by default
   readPhoneStateEnabled: true|false, // true by default,

--- a/android/src/main/java/io/underscope/react/fbak/RNAccountKitModule.java
+++ b/android/src/main/java/io/underscope/react/fbak/RNAccountKitModule.java
@@ -219,10 +219,9 @@ public class RNAccountKitModule extends ReactContextBaseJavaModule implements Ac
 
         String initialPhoneCountryPrefix = this.options.getString("initialPhoneCountryPrefix");
         String initialPhoneNumber = this.options.getString("initialPhoneNumber");
-        if (initialPhoneNumber != null && !initialPhoneNumber.isEmpty()) {
-            PhoneNumber phoneNumber = new PhoneNumber(initialPhoneCountryPrefix, initialPhoneNumber, null);
-            configurationBuilder.setInitialPhoneNumber(phoneNumber);
-        }
+
+        PhoneNumber phoneNumber = new PhoneNumber(initialPhoneCountryPrefix, initialPhoneNumber, null);
+        configurationBuilder.setInitialPhoneNumber(phoneNumber);
 
         configurationBuilder.setFacebookNotificationsEnabled(
                 this.options.getBoolean("facebookNotificationsEnabled"));

--- a/android/src/main/java/io/underscope/react/fbak/RNAccountKitModule.java
+++ b/android/src/main/java/io/underscope/react/fbak/RNAccountKitModule.java
@@ -219,7 +219,7 @@ public class RNAccountKitModule extends ReactContextBaseJavaModule implements Ac
 
         String initialPhoneCountryPrefix = this.options.getString("initialPhoneCountryPrefix");
         String initialPhoneNumber = this.options.getString("initialPhoneNumber");
-        if (initialPhoneCountryPrefix != null && !initialPhoneCountryPrefix.isEmpty() && initialPhoneNumber != null && !initialPhoneNumber.isEmpty()) {
+        if (initialPhoneNumber != null && !initialPhoneNumber.isEmpty()) {
             PhoneNumber phoneNumber = new PhoneNumber(initialPhoneCountryPrefix, initialPhoneNumber, null);
             configurationBuilder.setInitialPhoneNumber(phoneNumber);
         }


### PR DESCRIPTION
don't need required phone country prefix, it will be default by phone local country prefix.