### PR TITLE
Doesn't work on a presented ViewController (Modal)

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -338,7 +338,8 @@ RNAccountKit.configure({
   countryWhitelist: ['AR'], // [] by default
   countryBlacklist: ['US'], // [] by default
   defaultCountry: 'AR',
-  theme: {...} // for iOS only, see the Theme section
+  theme: {...}, // for iOS only, see the Theme section
+  viewControllerMode: 'show'|'present' // for iOS only, 'present' by default
 })
 ```
 
@@ -390,6 +391,23 @@ RNAccountKit.configure({
 ```
 
 Issue: [#68](https://github.com/underscopeio/react-native-facebook-account-kit/issues/68)
+
+</details>
+
+<details>
+    <summary>iOS only: Login screen doesn't show up</summary>
+<br/>
+
+In some cases, if you implement the Login button in a presented Modal screen, you need to add `viewControllerMode: 'show'` into the configuration.
+
+```javascript
+// Configures the SDK with some options
+RNAccountKit.configure({
+    viewControllerMode: 'show'
+    ...
+})
+```
+Issue: [#167](https://github.com/underscopeio/react-native-facebook-account-kit/issues/167)
 
 </details>
 

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ class RNAccountKit {
     readPhoneStateEnabled: true,
     receiveSMS: true,
     theme: {},
+    viewControllerMode: 'present' // for iOS only
   }
 
   constructor() {

--- a/ios/RNAccountKit.m
+++ b/ios/RNAccountKit.m
@@ -30,6 +30,12 @@ RCT_EXPORT_METHOD(login:(NSString *)type
         a.initialPhoneCountryPrefix = [self.options valueForKey:@"initialPhoneCountryPrefix"];
         a.initialPhoneNumber = [self.options valueForKey:@"initialPhoneNumber"];
 
+        if ([self.options valueForKey:@"viewControllerMode"]) {
+          a.viewControllerMode = [self.options valueForKey:@"viewControllerMode"];
+        } else {
+          a.viewControllerMode = @"present";
+        }
+        
         if ([type isEqual: @"phone"]) {
             [a loginWithPhone: resolve rejecter: reject];
         } else {

--- a/ios/RNAccountKitViewController.h
+++ b/ios/RNAccountKitViewController.h
@@ -13,6 +13,7 @@
 @property(nonatomic, strong) NSString *initialEmail;
 @property(nonatomic, strong) NSString *initialPhoneNumber;
 @property(nonatomic, strong) NSString *initialPhoneCountryPrefix;
+@property(nonatomic, strong) NSString *viewControllerMode;
 
 - (instancetype) initWithAccountKit: (AKFAccountKit *)accountKit;
 

--- a/ios/RNAccountKitViewController.m
+++ b/ios/RNAccountKitViewController.m
@@ -58,7 +58,7 @@
         UIViewController<AKFViewController> *viewController = [_accountKit viewControllerForPhoneLoginWithPhoneNumber:prefillPhoneNumber state:inputState];
         [self _prepareLoginViewController:viewController];
         UIViewController *rootViewController = [UIApplication sharedApplication].delegate.window.rootViewController;
-        [rootViewController presentViewController:viewController animated:YES completion:NULL];
+        [rootViewController showViewController:viewController sender:nil];
     });
 }
 
@@ -74,7 +74,7 @@
         UIViewController<AKFViewController> *viewController = [_accountKit viewControllerForEmailLoginWithEmail:prefillEmail state:inputState];
         [self _prepareLoginViewController:viewController];
         UIViewController *rootViewController = [UIApplication sharedApplication].delegate.window.rootViewController;
-        [rootViewController presentViewController:viewController animated:YES completion:NULL];
+        [rootViewController showViewController:viewController sender:nil];
     });
 }
 

--- a/ios/RNAccountKitViewController.m
+++ b/ios/RNAccountKitViewController.m
@@ -60,7 +60,7 @@
         UIViewController *rootViewController = [UIApplication sharedApplication].delegate.window.rootViewController;
         
         if([_viewControllerMode isEqualToString:@"present"]) {
-          [rootViewController showDetailViewController:viewController sender:nil];
+          [rootViewController presentViewController:viewController animated:YES completion:nil];
         } else if ([_viewControllerMode isEqualToString:@"show"]) {
           [rootViewController showViewController:viewController sender:nil];
         }
@@ -81,7 +81,7 @@
         UIViewController *rootViewController = [UIApplication sharedApplication].delegate.window.rootViewController;
         
         if([_viewControllerMode isEqualToString:@"present"]) {
-          [rootViewController showDetailViewController:viewController sender:nil];
+          [rootViewController presentViewController:viewController animated:YES completion:nil];
         } else if ([_viewControllerMode isEqualToString:@"show"]) {
           [rootViewController showViewController:viewController sender:nil];
         }

--- a/ios/RNAccountKitViewController.m
+++ b/ios/RNAccountKitViewController.m
@@ -58,7 +58,12 @@
         UIViewController<AKFViewController> *viewController = [_accountKit viewControllerForPhoneLoginWithPhoneNumber:prefillPhoneNumber state:inputState];
         [self _prepareLoginViewController:viewController];
         UIViewController *rootViewController = [UIApplication sharedApplication].delegate.window.rootViewController;
-        [rootViewController showViewController:viewController sender:nil];
+        
+        if([_viewControllerMode isEqualToString:@"present"]) {
+          [rootViewController showDetailViewController:viewController sender:nil];
+        } else if ([_viewControllerMode isEqualToString:@"show"]) {
+          [rootViewController showViewController:viewController sender:nil];
+        }
     });
 }
 
@@ -74,7 +79,12 @@
         UIViewController<AKFViewController> *viewController = [_accountKit viewControllerForEmailLoginWithEmail:prefillEmail state:inputState];
         [self _prepareLoginViewController:viewController];
         UIViewController *rootViewController = [UIApplication sharedApplication].delegate.window.rootViewController;
-        [rootViewController showViewController:viewController sender:nil];
+        
+        if([_viewControllerMode isEqualToString:@"present"]) {
+          [rootViewController showDetailViewController:viewController sender:nil];
+        } else if ([_viewControllerMode isEqualToString:@"show"]) {
+          [rootViewController showViewController:viewController sender:nil];
+        }
     });
 }
 


### PR DESCRIPTION
Fix the way we show accountkit navigation controller:
Old way's issues: If we call AccountKit from a presentedViewController (Modal), it won't work. Error log:
Warning: Attempt to present <AKFNavigationController: 0x107000000>  on <UIViewController: 0x1061398d0> which is already presenting <RCTModalHostViewController: 0x1060d0bc0>
Seems like the App's current ViewController is busy presenting the modal which wants to present AccountKit.