### PR TITLE
Fix crash when React context activity is null

### DIFF
--- a/android/src/main/java/io/underscope/react/fbak/RNAccountKitModule.java
+++ b/android/src/main/java/io/underscope/react/fbak/RNAccountKitModule.java
@@ -112,7 +112,11 @@ public class RNAccountKitModule extends ReactContextBaseJavaModule implements Ac
         final AccountKitConfiguration.AccountKitConfigurationBuilder configurationBuilder =
                 createAccountKitConfiguration(loginType);
         intent.putExtra(AccountKitActivity.ACCOUNT_KIT_ACTIVITY_CONFIGURATION, configurationBuilder.build());
-        this.reactContext.startActivityForResult(intent, APP_REQUEST_CODE, new Bundle());
+        try {
+            this.reactContext.startActivityForResult(intent, APP_REQUEST_CODE, new Bundle());
+        } catch (Error e) {
+            rejectPromise("error", new Error("Login aborted"));
+        }
     }
 
     @ReactMethod


### PR DESCRIPTION
It fixes crash:
java.lang.AssertionError: 
	at com.facebook.infer.annotation.Assertions.assertNotNull()(Assertions.java:28)
	at com.facebook.react.bridge.ReactContext.startActivityForResult()(ReactContext.java:326)
	at io.underscope.react.fbak.RNAccountKitModule.login()(RNAccountKitModule.java:115)
	at java.lang.reflect.Method.invoke()(Method.java:-2)
	at com.facebook.react.bridge.JavaMethodWrapper.invoke()(JavaMethodWrapper.java:372)
	at com.facebook.react.bridge.JavaModuleWrapper.invoke()(JavaModuleWrapper.java:160)
	at com.facebook.react.bridge.queue.NativeRunnable.run()(NativeRunnable.java:-2)
	at android.os.Handler.handleCallback()(Handler.java:790)
	at android.os.Handler.dispatchMessage()(Handler.java:99)
	at com.facebook.react.bridge.queue.MessageQueueThreadHandler.dispatchMessage()(MessageQueueThreadHandler.java:29)
	at android.os.Looper.loop()(Looper.java:164)
	at com.facebook.react.bridge.queue.MessageQueueThreadImpl$3.run()(MessageQueueThreadImpl.java:192)
	at java.lang.Thread.run()(Thread.java:764)

Crash can be observed when RN app is launched and RNAccountKit.loginWithPhone is called from some ComponentDidMount. At the same time user press Home button to send RN app to bg.

When RN app is in background then method presented below throws error, which crash app:
public boolean startActivityForResult(Intent intent, int code, Bundle bundle) {
    Activity activity = getCurrentActivity();
    Assertions.assertNotNull(activity);
    activity.startActivityForResult(intent, code, bundle);
    return true;
  }
