### PR TITLE
Update configure for enableSendToFacebook and enableGetACall. Fixes #161

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -340,6 +340,7 @@ RNAccountKit.configure({
   defaultCountry: 'AR',
   theme: {...}, // for iOS only, see the Theme section
   viewControllerMode: 'show'|'present' // for iOS only, 'present' by default
+  getACallEnabled: true|false
 })
 ```
 

--- a/index.js
+++ b/index.js
@@ -29,7 +29,8 @@ class RNAccountKit {
     readPhoneStateEnabled: true,
     receiveSMS: true,
     theme: {},
-    viewControllerMode: 'present' // for iOS only
+    viewControllerMode: 'present', // for iOS only
+    getACallEnabled: true
   }
 
   constructor() {
@@ -52,7 +53,7 @@ class RNAccountKit {
     }
 
     for (let key of Object.keys(options)) {
-      options[key] || delete options[key]
+      options.hasOwnProperty(key) || delete options[key]
     }
 
     const configOptions = {

--- a/ios/RNAccountKit.m
+++ b/ios/RNAccountKit.m
@@ -36,6 +36,18 @@ RCT_EXPORT_METHOD(login:(NSString *)type
           a.viewControllerMode = @"present";
         }
         
+        if ([[self.options valueForKey:@"facebookNotificationsEnabled"] boolValue] == YES) {
+            a.facebookNotificationsEnabled = YES;
+        } else {
+            a.facebookNotificationsEnabled = NO;
+        }
+        
+        if ([[self.options valueForKey:@"getACallEnabled"] boolValue] == YES) {
+            a.getACallEnabled = YES;
+        } else {
+            a.getACallEnabled = NO;
+        }
+        
         if ([type isEqual: @"phone"]) {
             [a loginWithPhone: resolve rejecter: reject];
         } else {

--- a/ios/RNAccountKitViewController.h
+++ b/ios/RNAccountKitViewController.h
@@ -14,6 +14,8 @@
 @property(nonatomic, strong) NSString *initialPhoneNumber;
 @property(nonatomic, strong) NSString *initialPhoneCountryPrefix;
 @property(nonatomic, strong) NSString *viewControllerMode;
+@property(nonatomic, assign) BOOL facebookNotificationsEnabled;
+@property(nonatomic, assign) BOOL getACallEnabled;
 
 - (instancetype) initWithAccountKit: (AKFAccountKit *)accountKit;
 

--- a/ios/RNAccountKitViewController.m
+++ b/ios/RNAccountKitViewController.m
@@ -40,6 +40,12 @@
     if (self.countryBlacklist != nil) {
         viewController.blacklistedCountryCodes = self.countryBlacklist;
     }
+    if (self.facebookNotificationsEnabled == YES) {
+        viewController.enableSendToFacebook = self.facebookNotificationsEnabled;
+    }
+    if (self.getACallEnabled == YES) {
+        viewController.enableGetACall = self.getACallEnabled;
+    }
     viewController.defaultCountryCode = self.defaultCountry;
 
 }


### PR DESCRIPTION
This PR is for #161 
I'll also want to use receiving phone calls. So I added the configuration for `enableSendToFacebook` and `enableGetACall` on iOS.
I hope to use this functions.