### PR TITLE
support androidx

### DIFF
--- a/android/src/main/java/io/underscope/react/fbak/RNAccountKitModule.java
+++ b/android/src/main/java/io/underscope/react/fbak/RNAccountKitModule.java
@@ -5,7 +5,7 @@ import android.Manifest;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
-import android.support.v4.content.ContextCompat;
+import androidx.core.content.ContextCompat;
 import android.util.Log;
 
 import com.facebook.accountkit.AccessToken;


### PR DESCRIPTION
The library does not compile in a new project with AndroidX enabled
[RN will move to AndroidX with the upcoming release](https://github.com/facebook/react-native/issues/23112#issuecomment-480425712)

This should fix it.
