### PR TITLE
Set Method queue to main queue.

### DIFF
--- a/ios/RNAccountKit.m
+++ b/ios/RNAccountKit.m
@@ -16,6 +16,10 @@
 
 RCT_EXPORT_MODULE();
 
+- (dispatch_queue_t)methodQueue
+{
+    return dispatch_get_main_queue();
+}
 
 RCT_EXPORT_METHOD(login:(NSString *)type
                   resolver: (RCTPromiseResolveBlock)resolve


### PR DESCRIPTION
All current methods include login are invoked from react-native js thread. Meanwhile Initialize a ViewController or any action related to UI need to be executed on Main thread.